### PR TITLE
Change bash to sh

### DIFF
--- a/logger.sh
+++ b/logger.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 LOG_PATH="$1"
 

--- a/main.sh
+++ b/main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # process arguments
 RUNNER_SCRIPT=$1


### PR DESCRIPTION
> The R docker image I'm preparing, is based on alpine linux and doesn't come with a bash shell (alpine uses the ash shell). 
> 
> Can `#!/bin/bash` be replaced with `#!/bin/sh` in main.sh and logger.sh? If not, I'll install the bash shell in the docker image (but I like to keep it as minimal as possible).
> --  `@jfmeys`  in #5 

- [ ] Test all judges
  - [ ] anaconda3
  - [ ] bash
  - [ ] biopythia
  - [x] haskell
  - [x] java
  - [ ] nodejs
  - [x] prolog
  - [ ] scratch



_[Original pull request](https://github.ugent.be/dodona/docker-images/pull/6) by @beardhatcode on Thu Apr 05 2018 at 22:53._