### PR TITLE
Support bc command in java judge

### DIFF
--- a/dodona-java.dockerfile
+++ b/dodona-java.dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 # Install jq for json querying in bash
 RUN ["apt-get", "update"]
-RUN ["apt-get", "-y", "install", "jshon"]
+RUN ["apt-get", "-y", "install", "jshon", "bc"]
 
 # Make sure the students can't find our secret path, which is mounted in
 # /mnt with a secure random name.


### PR DESCRIPTION
The new Java judge requires the `bc` command to show the amount of errors and warnings in the badge of the Compiler tab.

![image](https://github.ugent.be/storage/user/2678/files/8ec4d200-5afd-11e9-9d13-32bb5cb24cc1)


```bash
# Parse the amount of compilation errors and warnings.
compile_err_count=$(compilation_error_count "$compile_err")
compile_warn_count=$(compilation_warning_count "$compile_err")
compile_errwarn_sum=$(echo $compile_err_count + $compile_warn_count | bc)
```

Unless some other creative approach exists.

_[Original pull request](https://github.ugent.be/dodona/docker-images/pull/9) by @thepieterdc on Tue Apr 09 2019 at 19:25._
_Merged by @thepieterdc on Tue Apr 09 2019 at 20:10._