### PR TITLE
Fix dodona-security dependencies

### DIFF
--- a/dodona-security.dockerfile
+++ b/dodona-security.dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.11.3
 
-RUN apk add --no-cache nodejs=12.14.0-r0 yarn=1.19.2-r0 shadow=4.7-r1 \
+RUN apk add --no-cache yarn=1.19.2-r0 shadow=4.7-r1 \
                        jq=1.6-r0 bash=5.0.11-r1 curl=7.67.0-r0 sed=4.7-r0 \
-                       python3=3.8.1-r0 \
+                       python3=3.8.2-r0 \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && chmod 711 /mnt \
     && adduser -D runner


### PR DESCRIPTION
- Remove superfluous dependency on nodejs (already required by yarn)
- Update python3 to 3.8.2