### PR TITLE
Update Haskell to Stack LTS 16.14

### DIFF
--- a/dodona-haskell.dockerfile
+++ b/dodona-haskell.dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/runner
 USER runner
 RUN cabal update \
  # happy must be installed to install haskell-src-exts
- && cabal install happy-1.19.9 \
+ && cabal install happy-1.19.12 \
  && cabal install \
         hlint-3.1.6 \
         QuickCheck-2.13.2 \

--- a/dodona-haskell.dockerfile
+++ b/dodona-haskell.dockerfile
@@ -1,4 +1,4 @@
-FROM haskell:8.2
+FROM haskell:8.8.4
 
 RUN apt-get update \
  # Install jq for json querying in bash
@@ -20,13 +20,12 @@ RUN cabal update \
  # happy must be installed to install haskell-src-exts
  && cabal install happy-1.19.9 \
  && cabal install \
-        hlint-2.1.10 \
-        QuickCheck-2.10.1 \
+        hlint-3.1.6 \
+        QuickCheck-2.13.2 \
         HUnit-1.6.0.0 \
-        MissingH-1.4.0.1 \
-        json-builder-0.3 \
-        stm-2.4.5.0 \
-        gloss-1.13.0.1 \
+        MissingH-1.4.3.0 \
+        stm-2.5.0.0 \
+        gloss-1.13.1.2 \
  # Clearing package cache
  && rm -rf /home/runner/.cabal/packages/* \
  # Create the working directory


### PR DESCRIPTION
Closes #85 

8.10, which dependabot proposes, isn't in Stack LTS yet.

It seems this update was previously blocked by a missing json-builder. (I [fixed this last summer](https://github.com/ninewise/json-builder/commit/ea3c0c8ca4c8576d807817122c6c63097358f237) and [forgot about it](https://github.com/dodona-edu/judge-haskell/commit/e03d13f2349874576896c9945b0d2db53d474493))

I'll merge this after approval together with the judge update.