### PR TITLE
Fix installing R packages with native dependencies

### DIFF
--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -3,7 +3,7 @@ FROM r-base:4.0.2
 # Make sure the students can't find our secret path, which is mounted in
 # /mnt with a secure random name.
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends procps=2:3.3.16-5 && \
+  apt-get install -y --no-install-recommends procps=2:3.3.16-5 libcurl4-openssl-dev=7.72.0-1 libssl-dev=1.1.1g-1 libxml2-dev=2.9.10+dfsg-6 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   chmod 711 /mnt && \
@@ -12,33 +12,35 @@ RUN apt-get update && \
   mkdir -p /home/runner/workdir && \
   chown -R runner:runner /home/runner && \
   chown -R runner:runner /mnt && \
-  Rscript -e "install.packages('jsonlite')" && \
-  Rscript -e "install.packages('base64enc')" && \
-  Rscript -e "install.packages('R6')" && \
-  Rscript -e "install.packages('GGally')" && \
-  Rscript -e "install.packages('HistData')" && \
-  Rscript -e "install.packages('NHANES')" && \
-  Rscript -e "install.packages('RColorBrewer')" && \
-  Rscript -e "install.packages('car')" && \
-  Rscript -e "install.packages('coin')" && \
-  Rscript -e "install.packages('dplyr')" && \
-  Rscript -e "install.packages('dslabs')" && \
-  Rscript -e "install.packages('ggplot2')" && \
-  Rscript -e "install.packages('ggrepel')" && \
-  Rscript -e "install.packages('ggridges')" && \
-  Rscript -e "install.packages('ggthemes')" && \
-  Rscript -e "install.packages('gridExtra')" && \
-  Rscript -e "install.packages('kableExtra')" && \
-  Rscript -e "install.packages('multcomp')" && \
-  Rscript -e "install.packages('plotrix')" && \
-  Rscript -e "install.packages('scales')" && \
-  Rscript -e "install.packages('scatterplot3d')" && \
-  Rscript -e "install.packages('tidyverse')" && \
-  Rscript -e "install.packages('ISLR')" && \
-  Rscript -e "install.packages('MASS')" && \
-  Rscript -e "install.packages('glmnet')" && \
-  Rscript -e "install.packages('leaps')" && \
-  Rscript -e "install.packages('pls')"
+  Rscript -e "install.packages(c( \
+        'GGally' \
+      , 'HistData' \
+      , 'ISLR' \
+      , 'MASS' \
+      , 'NHANES' \
+      , 'R6' \
+      , 'RColorBrewer' \
+      , 'base64enc' \
+      , 'car' \
+      , 'coin' \
+      , 'dplyr' \
+      , 'dslabs' \
+      , 'ggplot2' \
+      , 'ggrepel' \
+      , 'ggridges' \
+      , 'ggthemes' \
+      , 'glmnet' \
+      , 'gridExtra' \
+      , 'jsonlite' \
+      , 'kableExtra' \
+      , 'leaps' \
+      , 'multcomp' \
+      , 'plotrix' \
+      , 'pls' \
+      , 'scales' \
+      , 'scatterplot3d' \
+      , 'tidyverse' \
+    ))"
 
 
 USER runner


### PR DESCRIPTION
Also move the installation of packages into one command, so we can at least see the failing packages at the end of the (Docker) build step.

Fixes #114.