### PR TITLE
Add packages necessary for Machine Learning course

### DIFF
--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -20,11 +20,15 @@ RUN apt-get update && \
       , 'NHANES' \
       , 'R6' \
       , 'RColorBrewer' \
+      , 'ROCR' \
       , 'base64enc' \
       , 'car' \
       , 'coin' \
       , 'dplyr' \
       , 'dslabs' \
+      , 'e1071' \
+      , 'gam' \
+      , 'gbm' \
       , 'ggplot2' \
       , 'ggrepel' \
       , 'ggridges' \
@@ -37,9 +41,11 @@ RUN apt-get update && \
       , 'multcomp' \
       , 'plotrix' \
       , 'pls' \
+      , 'randomForest' \
       , 'scales' \
       , 'scatterplot3d' \
       , 'tidyverse' \
+      , 'tree' \
     ))"
 
 


### PR DESCRIPTION
This commit adds packages necessary for Machine Learning course (F000942) given by prof. dr. Dries Benoit.

This commit add six packages to r dockerfile:
- tree: package with functions to fit classification and regression decision tree models
- randomForest: package with functions to fit classification and regression random forest models
- gbm: package with functions to fit generalized boosted regression models
- e1071: package with functions to fit support vector classifiers and regressors
- gam: package with functions to fit generalized additive models
- ROCR: package with functions to create popular visualisations of classification performance measures (ROC graphs, sensitivity/ specificity curves, lift charts...)