### PR TITLE
Add BART package for ISL book

### DIFF
--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
   chown -R runner:runner /home/runner && \
   chown -R runner:runner /mnt && \
   Rscript -e "install.packages(c( \
-        'GGally' \
+        'BART' \
+      , 'GGally' \
       , 'HistData' \
       , 'ISLR2' \
       , 'MASS' \


### PR DESCRIPTION
This commits the BART package necessary for the course of Data Mining that follows the Introduction of Statistical Learning book. The BART package implements functions to train Bayesian Additive Regression Trees.