### PR TITLE
fix wrong libcairo2 library

### DIFF
--- a/dodona-python.dockerfile
+++ b/dodona-python.dockerfile
@@ -9,7 +9,7 @@ RUN chmod 711 /mnt && \
      g++=4:10.2.1-1 \
      fontconfig=2.13.1-4.2 \
      libc6-dev=2.31-13+deb11u3 \
-     libcairo2-dev=1.16.0-5 \
+     libcairo2=1.16.0-5 \
      make=4.3-4.1 \
      procps=2:3.3.17-5 \
      wget=1.21-1+deb11u1 \


### PR DESCRIPTION
judge-turtle does not work with libcairo2-dev; instead libcairo2 should be used