### PR TITLE
python: don't uninstall libc6-dev and zlib1g-dev

### DIFF
--- a/dodona-python.dockerfile
+++ b/dodona-python.dockerfile
@@ -47,7 +47,7 @@ WORKDIR /tmp
 
 RUN rm fasta-36.3.8h.tar.gz fasta36-36.3.8h_04-May-2020 -r && \
   fc-cache -f && \
-  apt-get -y purge --autoremove gcc g++ libc6-dev make wget zlib1g-dev && \
+  apt-get -y purge --autoremove gcc g++ make wget && \
   mkdir -p /home/runner/workdir && \
   chown -R runner:runner /home/runner && \
   chown -R runner:runner /mnt


### PR DESCRIPTION
libcairo2-dev transiently depends on them, so when they are removed libcairo2 is
removed is well (which we do want to keep around).