### PR TITLE
Update Java from 17 to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [assembly, bash, c, compilers, csharp, haskell, html, java, java17, nodejs, prolog, python, r, scheme, sqlite, tested]
+        image: [assembly, bash, c, compilers, csharp, haskell, html, java, java21, nodejs, prolog, python, r, scheme, sqlite, tested]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [assembly, bash, c, compilers, csharp, haskell, html, java, java17, nodejs, prolog, python, r, scheme, sqlite, tested]
+        image: [assembly, bash, c, compilers, csharp, haskell, html, java, java21, nodejs, prolog, python, r, scheme, sqlite, tested]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/dodona-java21.dockerfile
+++ b/dodona-java21.dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jdk-alpine
 
 # Install jq for json querying in bash
-RUN apk add --update-cache jq \
+RUN apk add --no-cache jq=1.7.1-r0 \
  # Make sure the students can't find our secret path, which is mounted in
  # /mnt with a secure random name.
  && chmod 711 /mnt \

--- a/dodona-java21.dockerfile
+++ b/dodona-java21.dockerfile
@@ -1,13 +1,13 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:21-jdk-alpine
 
 # Install jq for json querying in bash
-RUN apt-get update && apt-get install -y --no-install-recommends jq=1.6-2.1 \
- && rm -rf /var/lib/apt/lists/* \
+RUN apk add --update-cache jq \
  # Make sure the students can't find our secret path, which is mounted in
  # /mnt with a secure random name.
  && chmod 711 /mnt \
  # Add the user which will run the student's code and the judge.
- && useradd -m runner
+ && adduser -S runner \
+ && rm -rf /var/cache/apk/*
 
 # As the runner user
 USER runner


### PR DESCRIPTION
This PR updates the Java version to 21 and switches the used base image to `eclipse-temurin:21-jdk-alpine`

Should be coordinated with https://github.com/dodona-edu/judge-java/pull/60