### PR TITLE
Fix java21: set UID to 1000

### DIFF
--- a/dodona-java21.dockerfile
+++ b/dodona-java21.dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache jq=1.7.1-r0 \
  # /mnt with a secure random name.
  && chmod 711 /mnt \
  # Add the user which will run the student's code and the judge.
- && adduser -S runner \
+ && adduser -u 1000 -S runner \
  && rm -rf /var/cache/apk/*
 
 # As the runner user


### PR DESCRIPTION
Apparently the alpine docker image gives a new user uid 100 instead of the expected 1000.

This PR manually overrides this uid for the adduser command.