### PR TITLE
Add make to Compilers Docker image

### DIFF
--- a/dodona-compilers.dockerfile
+++ b/dodona-compilers.dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     git \
     graphviz \
     libfmt-dev \
+    make \
     p7zip-full \
     pandoc \
     python3 \


### PR DESCRIPTION
Seems I forgot to explicitly add `make`...

It used to be pulled in as `Recommends` of the `cmake` package, but #307
adds `--no-install-recommends` to the `apt` commandline.

// cc: @wkverstr