### PR TITLE
Extend Scheme image with R7RS support

### DIFF
--- a/dodona-scheme.dockerfile
+++ b/dodona-scheme.dockerfile
@@ -7,6 +7,7 @@ RUN apt-get --allow-releaseinfo-change update \
     && apt-get clean \
     # add racket dependencies
     && raco pkg install -i --auto --binary-lib --no-cache --no-docs rackunit r5rs \
+    && raco pkg install -i --auto --no-cache --no-docs r7rs \
     # follow Dodona conventions
     && chmod 711 /mnt \
     && useradd -m runner \


### PR DESCRIPTION
Install `r7rs` Scheme as a source-based library in the dodona-scheme docker images, enabling courses to use R7RS in addition to the already supported R5RS.