### PR TITLE
Add matplotlib to tested docker file

### DIFF
--- a/dodona-tested.dockerfile
+++ b/dodona-tested.dockerfile
@@ -67,7 +67,9 @@ RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 \
  # Add the user which will run the student's code and the judge.
  && useradd -m runner \
  && mkdir /home/runner/workdir \
- && chown -R runner:runner /home/runner/workdir
+ && chown -R runner:runner /home/runner/workdir \
+ # Extra dependencies made available to python users
+ && pip install --no-cache-dir --upgrade matplotlib==3.9.1
 
 USER runner
 WORKDIR /home/runner/workdir


### PR DESCRIPTION
This pr adds matplotlib to the tested dockerfile.

I am not fully convinced we want to bloat the dockers even more with these kind of exercise dependencies. Might be worth thinking a bout a better solution to keep this all maintainable in the future.