### PR TITLE
Change base of dodona-docker image to busybox

### DIFF
--- a/dodona-docker.dockerfile
+++ b/dodona-docker.dockerfile
@@ -1,5 +1,6 @@
 FROM busybox:musl
 
+COPY --from=ghcr.io/bond-009/dodona-containerfile-evaluator:v0.1.0 /bin/dodona-containerfile-evaluator /bin/dodona-containerfile-evaluator
 COPY --from=hadolint/hadolint:2.12.0 /bin/hadolint /bin/hadolint
 COPY --from=ghcr.io/jqlang/jq:1.7.1 /jq /bin/jq
 COPY --from=gcr.io/kaniko-project/executor:v1.23.2-slim /kaniko /kaniko


### PR DESCRIPTION
This prevents the submitted Dockerfile from conflicting with any required dynamic libraries (by not having any).

* Decreases image size substatially
* Uses the certificates bundled with kaniko
* Replaces the sudo hack with renaming the root user to runner