### PR TITLE
Update Docker judge with latest containerfile-evaluator

### DIFF
--- a/dodona-docker.dockerfile
+++ b/dodona-docker.dockerfile
@@ -1,6 +1,6 @@
 FROM busybox:musl
 
-COPY --from=ghcr.io/bond-009/dodona-containerfile-evaluator:v0.2.0 /bin/dodona-containerfile-evaluator /bin/dodona-containerfile-evaluator
+COPY --from=ghcr.io/bond-009/dodona-containerfile-evaluator:v0.3.0 /bin/dodona-containerfile-evaluator /bin/dodona-containerfile-evaluator
 COPY --from=hadolint/hadolint:2.12.0 /bin/hadolint /bin/hadolint
 COPY --from=ghcr.io/jqlang/jq:1.7.1 /jq /bin/jq
 COPY --from=gcr.io/kaniko-project/executor:v1.23.2-slim /kaniko /kaniko


### PR DESCRIPTION
* Add ability to check EXPOSE instructions

https://github.com/Bond-009/dodona-containerfile-evaluator/releases/tag/v0.3.0

dodona-containerfile-evaluator is an important part of the Docker judge, would it make sense to also move it to the Dodona org @jorg-vr?