### PR TITLE
Add support for arm64 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,8 @@
-name: Publish
-
 on: [push]
 
-vars:
-  all_images: [assembly, bash, c, compilers, csharp, docker, haskell, html, java, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
-  amd64_only: [assembly, compilers, java, r]
+env:
+  ALL_IMAGES: assembly bash c compilers csharp docker haskell html java java21 nextflow nodejs postgres prolog python r scheme sqlite tested
+  AMD64_ONLY: assembly compilers java r
 
 jobs:
   build:
@@ -12,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ vars.all_images }}
+        image: ${{ env.ALL_IMAGES }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -28,4 +26,4 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: dodona-${{ matrix.image }}.dockerfile
         snapshot: true
-        platforms: ${{ contains(vars.amd64_only, matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+        platforms: ${{ contains(env.AMD64_ONLY, matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,4 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: dodona-${{ matrix.image }}.dockerfile
         snapshot: true
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Publish to Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 on: [push]
 
 env:
-  ALL_IMAGES: assembly bash c compilers csharp docker haskell html java java21 nextflow nodejs postgres prolog python r scheme sqlite tested
   AMD64_ONLY: assembly compilers java r
 
 jobs:
@@ -10,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ env.ALL_IMAGES }}
+        image: [assembly, bash, c, compilers, csharp, docker, haskell, html, java, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,17 @@ name: Publish
 
 on: [push]
 
+vars:
+  all_images: [assembly, bash, c, compilers, csharp, docker, haskell, html, java, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
+  amd64_only: [assembly, compilers, java, r]
+
 jobs:
   build:
     name: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
-        image: [assembly, bash, c, compilers, csharp, docker, haskell, html, java, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
+        image: ${{ vars.all_images }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -24,4 +28,4 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: dodona-${{ matrix.image }}.dockerfile
         snapshot: true
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ contains(vars.amd64_only, matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: Publish
+
 on: [push]
 
 env:

--- a/dodona-sqlite.dockerfile
+++ b/dodona-sqlite.dockerfile
@@ -1,21 +1,26 @@
-FROM python:3.12.4-slim-bullseye
+FROM python:3.12.9-slim-bookworm
 
-RUN apt-get update && \
-    # install procps, otherwise pkill cannot be not found
-    apt-get -y install --no-install-recommends \
-        procps=2:3.3.17-5 \
-        sqlite3=3.34.1-3 && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \
-    chmod 711 /mnt && \
-    useradd -m runner && \
-    mkdir -p /home/runner/workdir && \
-    chown -R runner:runner /home/runner && \
-    chown -R runner:runner /mnt && \
-    pip install --no-cache-dir --upgrade \
-        pandas==2.1.1 \
-        numpy==1.26.4 \
-        sqlparse==0.4.4
+RUN <<EOF
+  apt-get update
+
+  # install procps, otherwise pkill cannot be not found
+  apt-get -y install --no-install-recommends \
+    procps=2:4.0.2-3 \
+    sqlite3=3.40.1-2+deb12u1
+
+  rm -rf /var/lib/apt/lists/*
+  apt-get clean
+  chmod 711 /mnt
+  useradd -m runner
+  mkdir -p /home/runner/workdir
+  chown -R runner:runner /home/runner
+  chown -R runner:runner /mnt
+
+  pip install --no-cache-dir --upgrade \
+    pandas==2.1.1 \
+    numpy==1.26.4 \
+    sqlparse==0.4.4
+EOF
 
 USER runner
 WORKDIR /home/runner/workdir


### PR DESCRIPTION
This pull request adds support for arm64 images for many of our image files by adding an additional build target. I had to add a few exceptions for several reasons. In practice, this shouldn't be a huge problem since arm64 systems should be able to run x86 docker images.

Exceptions:
- assembly and compilers: the images and judges do architecture specific stuff. Not porting this for now.
- java: the base image doesn't have arm64 support. The judge was deprecated a long time ago, so we'll just remove it from Dodona next summer.
- r: the dockerfile has arm64 support, but the build takes over 6 hours which is the limit for github actions.