### PR TITLE
Update sqlite image

### DIFF
--- a/dodona-sqlite.dockerfile
+++ b/dodona-sqlite.dockerfile
@@ -1,21 +1,29 @@
-FROM python:3.12.4-slim-bullseye
+FROM python:3.12.9-slim-bookworm
 
-RUN apt-get update && \
-    # install procps, otherwise pkill cannot be not found
-    apt-get -y install --no-install-recommends \
-        procps=2:3.3.17-5 \
-        sqlite3=3.34.1-3 && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \
-    chmod 711 /mnt && \
-    useradd -m runner && \
-    mkdir -p /home/runner/workdir && \
-    chown -R runner:runner /home/runner && \
-    chown -R runner:runner /mnt && \
-    pip install --no-cache-dir --upgrade \
-        pandas==2.1.1 \
-        numpy==1.26.4 \
-        sqlparse==0.4.4
+RUN <<EOF
+  set -eux
+
+  apt-get update
+
+  # install procps, otherwise pkill cannot be not found
+  apt-get -y install --no-install-recommends \
+    procps=2:4.0.2-3 \
+    sqlite3=3.40.1-2+deb12u1
+
+  rm -rf /var/lib/apt/lists/*
+  apt-get clean
+
+  chmod 711 /mnt
+  useradd -m runner
+  mkdir -p /home/runner/workdir
+  chown -R runner:runner /home/runner
+  chown -R runner:runner /mnt
+
+  pip install --no-cache-dir --upgrade \
+    pandas==2.1.1 \
+    numpy==1.26.4 \
+    sqlparse==0.4.4
+EOF
 
 USER runner
 WORKDIR /home/runner/workdir


### PR DESCRIPTION
This pull request updates the sqlite image to 
- use a slightly newer python version
- updates it from debian bullseye to debian bookworm (including an update of debian packages)
- switches to heredoc syntax

This also fixes building an arm64 version of this image.