### PR TITLE
Update html image

### DIFF
--- a/dodona-html.dockerfile
+++ b/dodona-html.dockerfile
@@ -1,24 +1,33 @@
-FROM python:3.12.4-slim-bullseye
+FROM python:3.13.2-slim-bookworm
 
-RUN apt-get update && \
-    # install procps, otherwise pkill cannot be not found
-    apt-get -y install --no-install-recommends \
-        procps=2:3.3.17-5 && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \
-    chmod 711 /mnt && \
-    useradd -m runner && \
-    mkdir -p /home/runner/workdir && \
-    chown -R runner:runner /home/runner && \
-    chown -R runner:runner /mnt && \
-    pip install --no-cache-dir --upgrade \
-        beautifulsoup4==4.12.2 \
-        cssselect==1.2.0 \
-        lxml==4.9.3 \
-        tinycss2==1.2.1 \
-        py-emmet==1.2.0 \
-        html-similarity==0.3.3 \
-        colour==0.1.5
+RUN <<EOF
+  set -eux
+
+  apt-get update
+
+  # install procps, otherwise pkill cannot be not found
+  apt-get -y install --no-install-recommends \
+    procps=2:4.0.2-3
+
+  rm -rf /var/lib/apt/lists/*
+  apt-get clean
+
+  chmod 711 /mnt
+  useradd -m runner
+  mkdir -p /home/runner/workdir
+  chown -R runner:runner /home/runner
+  chown -R runner:runner /mnt
+
+
+  pip install --no-cache-dir --upgrade \
+    beautifulsoup4==4.13.3 \
+    cssselect==1.2.0 \
+    lxml==5.3.1 \
+    tinycss2==1.4.0 \
+    py-emmet==1.3.1 \
+    html-similarity==0.3.3 \
+    colour==0.1.5
+EOF
 
 USER runner
 WORKDIR /home/runner/workdir


### PR DESCRIPTION
This pull request updates the html image to 
- updates python to 3.13
- updates it from debian bullseye to debian bookworm (including an update of debian packages)
- updates all python packages, lxml had a major bump from 4.x to 5.x (it didn't compile with the older version)
- switches to heredoc syntax

This hopefully also fixes building an arm64 version of this image.