### PR TITLE
Fix java 21 docker image

### DIFF
--- a/dodona-java21.dockerfile
+++ b/dodona-java21.dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:21-jdk-alpine
 
 # Install jq for json querying in bash
-RUN apk add --no-cache jq \
+RUN apk add --no-cache jq=1.8.0-r0 \
  # Make sure the students can't find our secret path, which is mounted in
  # /mnt with a secure random name.
  && chmod 711 /mnt \


### PR DESCRIPTION
Fixes the following error:
```
 => ERROR [2/5] RUN apk add --no-cache jq=1.7.1-r0  && chmod 711 /mnt  && adduser -u 1000 -S runner  && rm -rf /var/cache/apk/*                                                                                                0.8s
------                                                                                                                                                                                                                              
 > [2/5] RUN apk add --no-cache jq=1.7.1-r0  && chmod 711 /mnt  && adduser -u 1000 -S runner  && rm -rf /var/cache/apk/*:                                                                                                           
0.103 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz                                                                                                                                                 
0.408 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
0.715 ERROR: unable to select packages:
0.716   jq-1.8.0-r0:
0.716     breaks: world[jq=1.7.1-r0]
------
dodona-java21.dockerfile:4
--------------------
   3 |     # Install jq for json querying in bash
   4 | >>> RUN apk add --no-cache jq=1.7.1-r0 \
   5 | >>>  # Make sure the students can't find our secret path, which is mounted in
   6 | >>>  # /mnt with a secure random name.
   7 | >>>  && chmod 711 /mnt \
   8 | >>>  # Add the user which will run the student's code and the judge.
   9 | >>>  && adduser -u 1000 -S runner \
  10 | >>>  && rm -rf /var/cache/apk/*
  11 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add --no-cache jq=1.7.1-r0  && chmod 711 /mnt  && adduser -u 1000 -S runner  && rm -rf /var/cache/apk/*" did not complete successfully: exit code: 1
```