### PR TITLE
Don't build for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: dodona-${{ matrix.image }}.dockerfile
         snapshot: true
-        platforms: ${{ contains(env.AMD64_ONLY, matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+        #platforms: ${{ contains(env.AMD64_ONLY, matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+        platforms: 'linux/amd64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Publish
 on: [push]
 
 env:
-  AMD64_ONLY: assembly compilers java r
+  AMD64_ONLY: '["assembly","compilers","java","r"]'
 
 jobs:
   build:
@@ -27,5 +27,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: dodona-${{ matrix.image }}.dockerfile
         snapshot: true
-        #platforms: ${{ contains(env.AMD64_ONLY, matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+        # platforms: ${{ contains(fromJson(env.AMD64_ONLY), matrix.image) && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
         platforms: 'linux/amd64'


### PR DESCRIPTION
This PR disables arm builds for the images.

We previously updated the build script to also support arm builds because we were planning to switch to AWS and arm runners. In the end, we opted for azure instead which runs amd64. The arm images are thus not urgently needed by us and because they are very slow to build, I disabled them again.