### PR TITLE
Fix R image

### DIFF
--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:4.4.2
+FROM r-base:4.5.1
 
 RUN <<EOF
   set -eux

--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -5,29 +5,17 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<'EOF'
   set -eux
   
-  # Detect the base suite (e.g., trixie, bookworm, sid)
   . /etc/os-release
   CODENAME="${VERSION_CODENAME:-trixie}"
   
-  # Tell apt to prefer the base suite and de-prefer unstable
-  printf 'APT::Default-Release "%s";\n' "$CODENAME" \
-    > /etc/apt/apt.conf.d/99defaultrelease
+  # Prefer the base suite by default
+  printf 'APT::Default-Release "%s";\n' "$CODENAME" > /etc/apt/apt.conf.d/99defaultrelease
   
-  cat > /etc/apt/preferences.d/00-pin <<PREF
-  Package: *
-  Pin: release n=${CODENAME}
-  Pin-Priority: 990
-  
-  Package: *
-  Pin: release a=unstable
-  Pin-Priority: 100
-PREF
-
   apt-get update
   
-  # Install build deps; let APT resolve matching runtimes from the same suite
-  # Note: correct package names for current Debian: libfontconfig1-dev, libfreetype6-dev
-  apt-get install -y --no-install-recommends \
+  # Install everything from unstable so *-dev matches already-installed runtimes
+  # (one shot avoids mixed versions)
+  apt-get install -y --no-install-recommends -t unstable \
     default-jdk \
     libcurl4-openssl-dev \
     libfontconfig1-dev \

--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -62,7 +62,6 @@ RUN <<'EOF'
     , 'caret' \
     , 'clickstream' \
     , 'coin' \
-    , 'coxed' \
     , 'data.table' \
     , 'devtools' \
     , 'dplyr' \
@@ -101,7 +100,6 @@ RUN <<'EOF'
     , 'qdap' \
     , 'randomForest' \
     , 'reshape2' \
-    , 'rtweet' \
     , 'rvest' \
     , 'scales' \
     , 'scatterplot3d' \
@@ -129,6 +127,12 @@ RUN <<'EOF'
     )), warning = function(w) stop(w))" \
     -e "library(devtools)" \
     -e "devtools::install_github('DougLuke/UserNetR')"
+
+  Rscript -e "install.packages('remotes', repos='https://cloud.r-project.org')"
+  # coxed archived — last CRAN version 0.3.3 (2020-08-02)
+  Rscript -e "remotes::install_version('coxed', version='0.3.3', repos='https://cran.r-project.org', dependencies=TRUE)"
+  # rtweet archived — last CRAN version 2.0.0 (2024-02-24)
+  Rscript -e "remotes::install_version('rtweet', version='2.0.0', repos='https://cran.r-project.org', dependencies=TRUE)"
 EOF
 
 USER runner

--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -4,6 +4,7 @@ RUN <<EOF
   set -eux
 
   apt-get update
+  apt-get -y dist-upgrade
   apt-get install -y --no-install-recommends \
     default-jdk \
     libcurl4-openssl-dev \

--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -4,14 +4,13 @@ RUN <<EOF
   set -eux
 
   apt-get update
-  apt-get install -y --no-install-recommends --allow-downgrades \
+  apt-get install -y --no-install-recommends \
     default-jdk \
     libcurl4-openssl-dev \
     libfontconfig-dev \
     libfreetype-dev \
     libfribidi-dev \
     libgit2-dev \
-    libglib2.0-0t64 \
     libglpk-dev \
     libgsl-dev \
     libharfbuzz-dev \

--- a/dodona-r.dockerfile
+++ b/dodona-r.dockerfile
@@ -21,8 +21,8 @@ RUN <<'EOF'
   Package: *
   Pin: release a=unstable
   Pin-Priority: 100
-  PREF
-  
+PREF
+
   apt-get update
   
   # Install build deps; let APT resolve matching runtimes from the same suite


### PR DESCRIPTION
This PR fixes the R image.

- The R version was update from 4.4.2 to 4.5.1. This required some additional changes to get apt packages installed because the base R image is a mess combining packages from different Debian versions.
- 2 packages were removed from rcran, I installed them using the archive.