### PR TITLE
Create latest tag on push to default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,7 @@ jobs:
         # Branch tags, PR tags, and a short-SHA tag
         tags: |
           type=ref,event=branch
-          type=sha,format=short
-        flavor: |
-          latest=auto # adds :latest only on default branch
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push (Docker Hub + GHCR)
       uses: docker/build-push-action@v6


### PR DESCRIPTION
This pull requests fixes the behaviour to automatically tag an image as latest when pushed to master (i.e. when merging a PR).