### PR TITLE
Update GitHub Actions to remove Docker Hub integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,13 +83,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
     - name: Log in to GHCR
       uses: docker/login-action@v3
       with:
@@ -102,14 +95,13 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: |
-          docker.io/dodona/dodona-${{ matrix.image }}
           ghcr.io/${{ github.repository_owner }}/dodona-${{ matrix.image }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr
           type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Build and push (Docker Hub + GHCR)
+    - name: Build and push (GHCR)
       uses: docker/build-push-action@v6
       with:
         context: .


### PR DESCRIPTION
Removed Docker Hub login step and updated build step to only push to GHCR.