### PR TITLE
Add matplotlib to dodona-python image

### DIFF
--- a/dodona-python.dockerfile
+++ b/dodona-python.dockerfile
@@ -15,21 +15,21 @@ RUN <<EOF
 
   # Judge dependencies
   pip install --no-cache-dir --upgrade \
-    Pillow==10.0.1 \
-    cairosvg==2.7.1 \
-    jsonschema==4.19.1 \
-    mako==1.2.4 \
-    psutil==5.9.5 \
-    pydantic==2.4.2 \
+    Pillow==12.2.0 \
+    cairosvg==2.9.0 \
+    jsonschema==4.26.0 \
+    mako==1.3.12 \
+    psutil==7.2.2 \
+    pydantic==2.13.4 \
     pyhumps==3.8.0 \
-    pylint==3.0.1 \
-    pyshp==2.3.1 \
-    setuptools==75.8.1 \
-    svg-turtle==0.4.2 \
+    pylint==4.0.5 \
+    pyshp==3.0.9 \
+    setuptools==82.0.1 \
+    svg-turtle==1.1.0 \
     typing-inspect==0.9.0
 
   # Exercise dependencies
-  pip install --no-cache-dir --upgrade numpy==1.26.0 biopython==1.81 sortedcontainers==2.4.0 pandas==2.1.1
+  pip install --no-cache-dir --upgrade numpy==2.4.6 biopython==1.87 sortedcontainers==2.4.0 pandas==3.0.3 matplotlib==3.10.9
   fc-cache -f
 
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Add `matplotlib==3.10.9` to both `dodona-python.dockerfile`
- In `dodona-python.dockerfile`: bring every pin up to current latest-stable (numpy → 2.4.6, pandas → 3.0.3, biopython → 1.87, Pillow → 12.2.0, cairosvg → 2.9.0, jsonschema → 4.26.0, mako → 1.3.12, psutil → 7.2.2, pydantic → 2.13.4, pylint → 4.0.5, pyshp → 3.0.9, setuptools → 82.0.1, svg-turtle → 1.1.0).

## Motivation

We already support `matplotlib` in the Pyodide-backed sandbox in Papyros, so students can write and run matplotlib code in the editor — but neither the `dodona-python` nor the `dodona-tested` judge image has matplotlib installed, so submitting that same code against an exercise fails on import. This PR closes the gap.

The tested dockerfile will be bumped in https://github.com/dodona-edu/docker-images/pull/411

## Image size impact

Built locally (arm64) against `master` and against this branch:

| Image | Before | After | Δ |
|---|---|---|---|
| `dodona-python` | 2.48 GB | 2.57 GB | +0.09 GB (+3.6%) |
| `dodona-tested` | 5.97 GB | 6.24 GB | +0.27 GB (+4.5%) |

⚠️ Tested numbers will change when merging https://github.com/dodona-edu/docker-images/pull/411 since that also reduced the size of dodona-tested by about 23%.

## Test plan

- [ ] CI builds image successfully.
- [ ] `docker run --rm dodona-python python -c "import matplotlib; print(matplotlib.__version__)"` prints `3.10.9`.
- [ ] Existing python-judge exercises still pass (sanity-check that the pin bumps didn't break anything depending on older numpy/pandas/Pillow).