### PR TITLE
Use ENV key=value syntax in dodona-tested.dockerfile

### DIFF
--- a/dodona-tested.dockerfile
+++ b/dodona-tested.dockerfile
@@ -13,15 +13,15 @@ FROM python:3.12.4-slim-bullseye
 # Set up the environment
 
 # Kotlin
-ENV SDKMAN_DIR /usr/local/sdkman
-ENV PATH $SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
-ENV PATH $SDKMAN_DIR/candidates/java/current/bin:$PATH
+ENV SDKMAN_DIR=/usr/local/sdkman
+ENV PATH=$SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
+ENV PATH=$SDKMAN_DIR/candidates/java/current/bin:$PATH
 # Haskell
-ENV HASKELL_DIR /usr/local/ghcupdir
-ENV PATH $HASKELL_DIR/ghc/bin:$PATH
-ENV PATH $HASKELL_DIR/cabal:$PATH
+ENV HASKELL_DIR=/usr/local/ghcupdir
+ENV PATH=$HASKELL_DIR/ghc/bin:$PATH
+ENV PATH=$HASKELL_DIR/cabal:$PATH
 # Node
-ENV NODE_PATH /usr/lib/node_modules
+ENV NODE_PATH=/usr/lib/node_modules
 
 # Install dependencies
 # hadolint ignore=DL3013,DL3016


### PR DESCRIPTION
## Summary

- Replace the 7 legacy space-separated `ENV key value` declarations in `dodona-tested.dockerfile` with the `ENV key=value` form.

## Motivation

The `tested` build on #404 emits seven `LegacyKeyValueFormat` BuildKit warnings:

```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 16)
... (lines 17, 18, 20, 21, 22, 24)
```

See: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

This PR clears those warnings.

> [!NOTE]
> `dodona-tested.dockerfile` is autogenerated from `dodona-edu/universal-judge`. A matching fix should also land in the template there to prevent regeneration from re-introducing the legacy form.

## Test plan

- [ ] CI lint job (hadolint) passes.
- [ ] `tested` Publish job builds without `LegacyKeyValueFormat` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)