### PR TITLE
Sync dodona-tested dockerfile with universal-judge

### DIFF
--- a/dodona-tested.dockerfile
+++ b/dodona-tested.dockerfile
@@ -13,21 +13,31 @@ FROM python:3.12.4-slim-bullseye
 # Set up the environment
 
 # Kotlin
-ENV SDKMAN_DIR /usr/local/sdkman
-ENV PATH $SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
-ENV PATH $SDKMAN_DIR/candidates/java/current/bin:$PATH
+ENV SDKMAN_DIR=/usr/local/sdkman
+ENV PATH=$SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
+ENV PATH=$SDKMAN_DIR/candidates/java/current/bin:$PATH
 # Haskell
-ENV HASKELL_DIR /usr/local/ghcupdir
-ENV PATH $HASKELL_DIR/ghc/bin:$PATH
-ENV PATH $HASKELL_DIR/cabal:$PATH
+ENV HASKELL_DIR=/usr/local/ghcupdir
+ENV PATH=$HASKELL_DIR/ghc/bin:$PATH
+ENV PATH=$HASKELL_DIR/cabal:$PATH
 # Node
-ENV NODE_PATH /usr/lib/node_modules
+ENV NODE_PATH=/usr/lib/node_modules
 
 # Install dependencies
 # hadolint ignore=DL3013,DL3016
 RUN <<EOF
     # Update apt-get
     apt-get update
+
+    # Drop docs/man/locale from all apt-installed packages (keep copyright for licensing)
+    cat > /etc/dpkg/dpkg.cfg.d/01_nodoc <<'CFG'
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+CFG
 
     # Install general dependencies
     apt-get install -y --no-install-recommends \
@@ -91,6 +101,12 @@ RUN <<EOF
     cabal update
     cabal v1-install --global aeson
 
+    # GHC: drop profiling libs/interfaces, haddock/HTML docs, and debug symbols (unused at runtime)
+    find "$HASKELL_DIR/ghc" -type f \( -name '*_p.a' -o -name '*.p_o' -o -name '*.p_hi' \) -delete
+    rm -rf "$HASKELL_DIR/ghc/share/doc" "$HASKELL_DIR/ghc"/lib/*/doc
+    find "$HASKELL_DIR/ghc" -type f -name '*.so*' -exec strip --strip-unneeded {} + 2>/dev/null || true
+    find "$HASKELL_DIR/ghc/bin" -type f -exec strip --strip-unneeded {} + 2>/dev/null || true
+
     # C# dependencies
     curl https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb --output packages-microsoft-prod.deb
     dpkg -i packages-microsoft-prod.deb
@@ -111,7 +127,9 @@ RUN <<EOF
 
     # Exercise dependencies
     pip install --no-cache-dir --upgrade \
-      numpy==2.3.5
+      numpy==2.3.5 \
+      pandas==3.0.1 \
+      openpyxl==3.1.5
 
     # Clean up caches
     apt-get clean
@@ -119,6 +137,14 @@ RUN <<EOF
     rm -rf /root/.cache
     rm -rf /root/.npm
     rm -rf /usr/local/sdkman/tmp
+    # Haskell: downloaded Hackage tarballs and ghcup download cache (aeson lives in GHC's global db)
+    rm -rf /root/.cabal/packages /root/.cabal/logs /root/.ghcup/cache /root/.ghcup/tmp
+    # .NET: NuGet/dotnet download and first-run caches (SDK itself untouched)
+    rm -rf /root/.nuget /root/.dotnet /tmp/NuGet* /tmp/.dotnet "${HOME}/.local/share/NuGet"
+    # sdkman: extracted JDK/Kotlin zips, plus JDK sources and man pages (not needed to compile/run)
+    rm -rf "$SDKMAN_DIR/archives/"* "$SDKMAN_DIR/tmp/"*
+    rm -f  "$SDKMAN_DIR"/candidates/java/*/src.zip
+    rm -rf "$SDKMAN_DIR"/candidates/java/*/man "$SDKMAN_DIR"/candidates/kotlin/*/licenses
 
     # Setup permissions and user
     chmod 711 /mnt


### PR DESCRIPTION
The automated sync workflow in `dodona-edu/universal-judge` (`Create pr for docker image`) failed to push this update — the `PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN` PAT (user `dodona-server`) returned a 403 (`Permission ... denied`). See [the failed run](https://github.com/dodona-edu/universal-judge/actions/runs/26630584906/job/78478114814). This PR applies the same change manually.

## What changed

`dodona-tested.dockerfile` is regenerated from `.devcontainer/dodona-tested.dockerfile` on universal-judge `master`, picking up:

- **`ENV key=value` syntax** (universal-judge #648 / dodona-edu/universal-judge#648) — replaces the deprecated `ENV key value` form.
- **Image-shrink changes** (universal-judge #646): drop docs/man/locale from apt packages via a dpkg config, strip GHC profiling libs/interfaces + haddock docs + debug symbols, and extra cache cleanup (cabal/ghcup/NuGet/dotnet/sdkman).
- **Exercise deps**: add `pandas==3.0.1` and `openpyxl==3.1.5`.

## How to test

Build the image and confirm it builds cleanly and is smaller than before:

```
docker build -f dodona-tested.dockerfile -t dodona-tested-test .
```

## Notes

The underlying CI failure (expired/revoked `PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN`) still needs fixing so future syncs are automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)