### PR TITLE
Sync dodona-tested dockerfile with universal-judge (ENV syntax)

### DIFF
--- a/dodona-tested.dockerfile
+++ b/dodona-tested.dockerfile
@@ -13,15 +13,15 @@ FROM python:3.12.4-slim-bullseye
 # Set up the environment
 
 # Kotlin
-ENV SDKMAN_DIR /usr/local/sdkman
-ENV PATH $SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
-ENV PATH $SDKMAN_DIR/candidates/java/current/bin:$PATH
+ENV SDKMAN_DIR=/usr/local/sdkman
+ENV PATH=$SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
+ENV PATH=$SDKMAN_DIR/candidates/java/current/bin:$PATH
 # Haskell
-ENV HASKELL_DIR /usr/local/ghcupdir
-ENV PATH $HASKELL_DIR/ghc/bin:$PATH
-ENV PATH $HASKELL_DIR/cabal:$PATH
+ENV HASKELL_DIR=/usr/local/ghcupdir
+ENV PATH=$HASKELL_DIR/ghc/bin:$PATH
+ENV PATH=$HASKELL_DIR/cabal:$PATH
 # Node
-ENV NODE_PATH /usr/lib/node_modules
+ENV NODE_PATH=/usr/lib/node_modules
 
 # Install dependencies
 # hadolint ignore=DL3013,DL3016


### PR DESCRIPTION
The automated sync workflow in `dodona-edu/universal-judge` (`Create pr for docker image`) failed to push this — the `PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN` PAT (user `dodona-server`) returned 403. That's fine, we don't want dodona-server to be running these commands anyway.

This PR syncs https://github.com/dodona-edu/universal-judge/blob/master/.devcontainer/dodona-tested.dockerfile into here. 