### PR TITLE
Sync dodona-tested dockerfile with universal-judge (ENV syntax)

### DIFF
--- a/dodona-tested.dockerfile
+++ b/dodona-tested.dockerfile
@@ -13,15 +13,15 @@ FROM python:3.12.4-slim-bullseye
 # Set up the environment
 
 # Kotlin
-ENV SDKMAN_DIR /usr/local/sdkman
-ENV PATH $SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
-ENV PATH $SDKMAN_DIR/candidates/java/current/bin:$PATH
+ENV SDKMAN_DIR=/usr/local/sdkman
+ENV PATH=$SDKMAN_DIR/candidates/kotlin/current/bin:$PATH
+ENV PATH=$SDKMAN_DIR/candidates/java/current/bin:$PATH
 # Haskell
-ENV HASKELL_DIR /usr/local/ghcupdir
-ENV PATH $HASKELL_DIR/ghc/bin:$PATH
-ENV PATH $HASKELL_DIR/cabal:$PATH
+ENV HASKELL_DIR=/usr/local/ghcupdir
+ENV PATH=$HASKELL_DIR/ghc/bin:$PATH
+ENV PATH=$HASKELL_DIR/cabal:$PATH
 # Node
-ENV NODE_PATH /usr/lib/node_modules
+ENV NODE_PATH=/usr/lib/node_modules
 
 # Install dependencies
 # hadolint ignore=DL3013,DL3016


### PR DESCRIPTION
The automated sync workflow in `dodona-edu/universal-judge` (`Create pr for docker image`) failed to push this — the `PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN` PAT (user `dodona-server`) returned 403. See [the failed run](https://github.com/dodona-edu/universal-judge/actions/runs/26630584906/job/78478114814). This PR applies the outstanding change manually.

## What changed

Brings `dodona-tested.dockerfile` fully in sync with universal-judge `master`. The only remaining delta is the `ENV` syntax — switching from the deprecated `ENV key value` form to `ENV key=value` (mirrors [universal-judge #648](https://github.com/dodona-edu/universal-judge/pull/648)).

Everything else already matches:

- **numpy / pandas / openpyxl** exercise dependencies were already synced here on March 4 (`55822ab`, the last successful automated push).
- The image-shrink work (dpkg doc/man/locale exclusion, GHC profiling/doc stripping, extra cache cleanup) is intentionally **not** included — it's still on an unmerged universal-judge branch.

Once this merges, `dodona-tested.dockerfile` matches universal-judge `master` exactly.

## How to test

```
docker build -f dodona-tested.dockerfile -t dodona-tested-test .
```

## Notes

The root-cause CI failure (expired/revoked `PUSH_TO_DOCKER_IMAGES_ACCESS_TOKEN`) still needs an admin to rotate the token so future syncs run automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)