### PR TITLE
Move GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build filters
         id: genfilters
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           IMAGES: ${{ env.IMAGES }}
         with:
@@ -36,13 +36,13 @@ jobs:
             core.setOutput('filters', JSON.stringify(map));
 
       - name: Detect changed images
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: ${{ steps.genfilters.outputs.filters }}
 
       - name: Set flags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: flags
         with:
           script: |
@@ -50,7 +50,7 @@ jobs:
             core.setOutput('rebuild_all', labels.includes('rebuild-all') ? 'true' : 'false');
 
       - name: Set matrix
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: set-matrix
         env:
           ALL_IMAGES: ${{ env.IMAGES }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
         image: [assembly, bash, c, compilers, csharp, docker, haskell, html, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: jbergstroem/hadolint-gh-action@v1
         with:
           dockerfile: dodona-${{ matrix.image }}.dockerfile


### PR DESCRIPTION
GitHub flagged the Node 20 actions in our workflows: they'll be forced to Node 24 on 2026-06-16, and Node 20 gets removed from the runners on 2026-09-16. This bumps them to their Node 24 releases.

### Testing

We'll see in CI I guess!

<details>

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

- **`actions/github-script@v7 → v8`** (build.yml, 3×). v8 is a pure runtime bump to Node 24. Stayed on v8 rather than v9 on purpose: v9 drops `require('@actions/github')` and injects `getOctokit`, but our scripts only use `core.setOutput`, `context.payload` and `process.env`, so neither would actually break, and v8 is the smaller jump.
- **`dorny/paths-filter@v3 → v4`** (build.yml). v4's only change is the Node 24 runtime; the `filters` input and `outputs.changes` are unchanged.
- **`actions/checkout@v4 → v5`** (lint.yml). Wasn't in the warning, but it's the same Node 20 deprecation and build.yml was already on v5.

`jbergstroem/hadolint-gh-action@v1` in lint.yml is a Docker action, so it's unaffected.

</details>