### PR TITLE
Track GitHub Actions versions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
     versions:
     - ">= 8.1.a"
     - "< 8.2"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "04:00"
+    timezone: Europe/Brussels
+  open-pull-requests-limit: 99


### PR DESCRIPTION
Dependabot only tracked the `docker` ecosystem, so nothing kept the GitHub Actions in our workflows (`actions/checkout`, `actions/github-script`, `docker/*`, `dorny/paths-filter`, `jbergstroem/hadolint-gh-action`) up to date. This adds a `github-actions` ecosystem entry so those bumps.

### Verification
- We'll see if it works I guess!