### PR TITLE
Add lxml to the python image

### DIFF
--- a/dodona-python.dockerfile
+++ b/dodona-python.dockerfile
@@ -29,7 +29,7 @@ RUN <<EOF
     typing-inspect==0.9.0
 
   # Exercise dependencies
-  pip install --no-cache-dir --upgrade numpy==2.4.6 biopython==1.87 sortedcontainers==2.4.0 pandas==3.0.3 matplotlib==3.10.9
+  pip install --no-cache-dir --upgrade numpy==2.4.6 biopython==1.87 sortedcontainers==2.4.0 pandas==3.0.3 matplotlib==3.10.9 lxml==6.1.1
   fc-cache -f
 
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds the `lxml` Python module (pinned to `lxml==6.1.1`) to the exercise dependencies of the python image, to keep it on par with the TESTed image (dodona-edu/universal-judge#660, requested in dodona-edu/dodona#5999).

| | Uncompressed (on disk) | Compressed (pull) |
|---|---|---|
| before | 1.87 GB | 0.56 GB |
| increase | **+12.14 MB** | **+5.44 MB** |

So ~0.65% on a 1.87 GB image.

<details>

`lxml` ships manylinux wheels with libxml2/libxslt bundled, so there's no compilation and no extra pip dependencies pulled in. Same version as the TESTed PR, so both images stay aligned.

## Image size impact

Measured by layering only this change on top of the published `dodona/dodona-python:latest` (amd64, digest `sha256:d4aa1701…`, built 2025-08-19) and comparing image sizes. On-disk is the runtime footprint, compressed is the registry/pull cost.

## How to verify

For a quick local check without a full rebuild, layer the change on the published image:

```sh
docker build --platform linux/amd64 -t python-lxml - <<'EOF'
FROM dodona/dodona-python:latest
USER root
RUN pip install --no-cache-dir --upgrade lxml==6.1.1
USER runner
EOF
docker run --rm --platform linux/amd64 python-lxml python -c "import lxml.etree; print(lxml.etree.__version__)"
# -> 6.1.1
```

## Note

This branches off `master`, which doesn't yet have the matplotlib work (in flight as #423). Both this and #423 edit the exercise-dependencies line, so expect a trivial one-line merge conflict, whichever lands second.

</details>