### PR TITLE
Add dodona-java as the new name for the modern Java image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
         default: false
 
 env:
-  IMAGES: '["assembly","bash","c","compilers","csharp","docker","haskell","html","java21","nextflow","nodejs","postgres","prolog","python","r","scheme","sqlite","tested"]'
+  IMAGES: '["assembly","bash","c","compilers","csharp","docker","haskell","html","java","java21","nextflow","nodejs","postgres","prolog","python","r","scheme","sqlite","tested"]'
 
 jobs:
   detect:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [assembly, bash, c, compilers, csharp, docker, haskell, html, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
+        image: [assembly, bash, c, compilers, csharp, docker, haskell, html, java, java21, nextflow, nodejs, postgres, prolog, python, r, scheme, sqlite, tested]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/dodona-java.dockerfile
+++ b/dodona-java.dockerfile
@@ -1,0 +1,7 @@
+# Transition alias for dodona-edu/dodona#7583: `dodona-java` is the new, version-less
+# name for the modern Java image (currently Java 25, still built as `dodona-java21`).
+# For now it just mirrors `dodona-java21` so both names are published while we migrate
+# the consumers. In the final step the real Dockerfile moves here and `dodona-java21`
+# is removed.
+# hadolint ignore=DL3007
+FROM ghcr.io/dodona-edu/dodona-java21:latest


### PR DESCRIPTION
Part of the `java21` → `java` rename (dodona-edu/dodona#7583). The modern Java image is version-pinned in its name (`dodona-java21`) but actually ships Java 25, so we're moving to a version-less `dodona-java` and will drop `dodona-java21` once everything's migrated.

This is **phase 1, step 1**: start publishing the image under the new name *alongside* the old one, so the judges (and the prod DB / worker pulls) keep working while we switch them over.

<details>

## What changed
- New `dodona-java.dockerfile` that for now just mirrors the existing image: `FROM ghcr.io/dodona-edu/dodona-java21:latest`.
- Added `java` to the build + lint image lists.

## Why alias the new name to the old image (and not the other way round)
We'd sketched making `dodona-java` the real Dockerfile and `dodona-java21` a `FROM dodona-java:latest` alias. But that can't go green in a single PR: the `java21` alias build would try to pull `dodona-java:latest`, which doesn't exist until this merges to master (chicken-and-egg). Pointing the new name at the already-published `dodona-java21` image sidesteps that, both names publish from one PR with identical bits. In the cleanup step the real Dockerfile moves into `dodona-java.dockerfile` and `dodona-java21.dockerfile` is deleted.

## Verify
- CI: the `java` matrix job builds + pushes `ghcr.io/dodona-edu/dodona-java` (only `java` rebuilds, `java21` is untouched).
- After merge: `docker pull ghcr.io/dodona-edu/dodona-java:latest` gives the same image as `dodona-java21:latest`.

<details>
<summary>Follow-ups (tracked in dodona-edu/dodona#7583)</summary>

- azure-images already lists `dodona-java:latest`, so the worker pulls need no change, the new image just has to be deployed to the servers (manual).
- Phase 2: switch `judge-java`, `judge-markdown`, the dodona seeds and the prod DB to `dodona-java`.
- Phase 3: move the real Dockerfile into `dodona-java.dockerfile` and remove `dodona-java21`.
</details>

</details>
